### PR TITLE
emit ready on connect

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,8 @@ var exec = function (cmd, opts) {
       stream.setWritable(stdio)
       stream.setReadable(stdio)
 
+      stream.emit('ready')
+
       stdio.stderr.setEncoding('utf-8')
       stdio.stderr.on('data', function (data) {
         stream.emit('warn', data)


### PR DESCRIPTION
ssh-exec did not emit the "ready" and there was no easy way to get that info so I added it.

Now you can do this:

```
var exec = require('ssh-exec');

exec('cmd', opts).on('ready', function() {
  console.log('SSH session started');
}).on('data', function(data) {
  // do something with the data
});
```