### PR TITLE
Exec options

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,6 @@ var exec = function (cmd, opts, cb) {
       if (!opts.fingerprint) return true
       if (fingerprint === opts.fingerprint) return true
 
-      client.destroy(new Error('Host could not be verified'))
       return false
     }
 

--- a/index.js
+++ b/index.js
@@ -57,9 +57,22 @@ var exec = function (cmd, opts, cb) {
       port: opts.port || 22,
       tryKeyboard: !!opts.password,
       privateKey: key,
-      agent: process.env.SSH_AUTH_SOCK,
-      hostHash: 'md5',
-      hostVerifier: verifier
+      allowAgentFwd: opts.allowAgentFwd,
+      agent: process.env.SSH_AUTH_SOCK || opts.agent,
+      hostHash: opts.hostHash || 'md5',
+      hostVerifier: verifier,
+      localUsername: opts.localUsername,
+      localHostname: opts.localHostname,
+      forceIPv4: opts.forceIPv4,
+      forceIPv6: opts.forceIPv6,
+      keepaliveCountMax: opts.keepaliveCountMax,
+      keepaliveInterval: opts.keepaliveInterval,
+      algorithms: opts.algorithms,
+      compress: opts.compress,
+      strictVendor: opts.strictVendor,
+      readyTimeout: opts.readyTimeout,
+      timeout: opts.timeout,
+      sock: opts.sock
     })
   }
 

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ var exec = function (cmd, opts, cb) {
   }
 
   var run = function () {
-    client.exec(cmd, function (err, stdio) {
+    client.exec(cmd, opts.exec || {}, function (err, stdio) {
       if (err) return stream.destroy(err)
 
       stream.setWritable(stdio)

--- a/index.js
+++ b/index.js
@@ -32,8 +32,6 @@ var exec = function (cmd, opts, cb) {
   })
 
   var connect = function () {
-    if (key && key.toString().toLowerCase().indexOf('encrypted') > -1) key = null
-
     var verifier = function (hash) {
       fingerprint = hash
 
@@ -52,11 +50,12 @@ var exec = function (cmd, opts, cb) {
     client.connect({
       host: opts.host,
       username: opts.user,
-      password: opts.password,
+      password: process.env.SSH_PASSWORD || opts.password,
+      passphrase: process.env.SSH_PASSPHRASE || opts.passphrase,
       port: opts.port || 22,
       tryKeyboard: !!opts.password,
       privateKey: key,
-      agent: process.env.SSH_AUTH_SOCK,
+      agent: process.env.SSH_AUTH_SOCK || opts.agent,
       hostHash: 'md5',
       hostVerifier: verifier
     })

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "duplexify": "^3.2.0",
     "once": "^1.3.3",
-    "ssh2": "^0.4.8"
+    "ssh2": "^0.5.0"
   },
   "devDependencies": {
     "standard": "^5.4.1"


### PR DESCRIPTION
Allow to set execute command options such as opts.exec = { env: ..., pty: ... } and so on.
